### PR TITLE
Broken link

### DIFF
--- a/README.textile
+++ b/README.textile
@@ -1,7 +1,6 @@
-
 h1. Rack::Webauth
 
-Rack middleware to acquire authentication information from a "Stanford WebAuth":http://webauth.stanford.edu/ system.
+Rack middleware to acquire authentication information from a "Stanford WebAuth":http://www.stanford.edu/services/webauth/ system.
 
 h2. Documentation
 


### PR DESCRIPTION
Hi there,

I just noticed a broken link in your README. The link to WebAuth page gives a 404 (perhaps temporarily); I changed it to the ITS WebAuth page.

Cheers,
  Lee :beer:
