### PR TITLE
Misspelling causing webauth.privgroup to always be nil

### DIFF
--- a/lib/rack-webauth.rb
+++ b/lib/rack-webauth.rb
@@ -131,7 +131,7 @@ class Rack::Webauth
     #
     # TOOD: implement detection of multiple privgroups
     def privgroup
-      @privgroup ||= env['WEABUTH_LDAPPRIVGROUP']
+      @privgroup ||= env['WEBAUTH_LDAPPRIVGROUP']
     end
 
     # Rule ("Require" statement) that authenticated this user


### PR DESCRIPTION
WEBAUTH_LDAPPRIVGROUP was misspelled as WEABUTH_LDAPPRIVGROUP
